### PR TITLE
Fix false-positive leak detection report when ReferenceCountedOpenSsl…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -235,7 +235,6 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                                   int peerPort, boolean jdkCompatibilityMode, boolean leakDetection) {
         super(peerHost, peerPort);
         OpenSsl.ensureAvailability();
-        leak = leakDetection ? leakDetector.track(this) : null;
         this.alloc = checkNotNull(alloc, "alloc");
         apn = (OpenSslApplicationProtocolNegotiator) context.applicationProtocolNegotiator();
         session = new OpenSslSession(context.sessionContext());
@@ -288,6 +287,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 PlatformDependent.throwException(cause);
             }
         }
+        leak = leakDetection ? leakDetector.track(this) : null;
     }
 
     /**

--- a/handler/src/test/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngineTest.java
@@ -15,7 +15,9 @@
  */
 package io.netty.handler.ssl;
 
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.util.ReferenceCountUtil;
+import org.junit.Test;
 
 import javax.net.ssl.SSLEngine;
 
@@ -53,5 +55,15 @@ public class ReferenceCountedOpenSslEngineTest extends OpenSslEngineTest {
     @Override
     protected void cleanupServerSslEngine(SSLEngine engine) {
         ReferenceCountUtil.release(engine);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNotLeakOnException() throws Exception {
+        clientSslCtx = SslContextBuilder.forClient()
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .sslProvider(sslClientProvider())
+                .build();
+
+        clientSslCtx.newEngine(null);
     }
 }


### PR DESCRIPTION
…Engine constructor throws.

Motivation:

We need to ensure we only create the ResourceLeak when the constructor not throws.

Modifications:

Ensure ResourceLeakDetector.track(...) is only called if the constructor of ReferenceCoundedOpenSslEngine not throws.

Result:

No more false-positves.

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
